### PR TITLE
use compiler intrinsics instead of asm

### DIFF
--- a/src/atomic.h
+++ b/src/atomic.h
@@ -8,30 +8,33 @@
 #define atomic_add(P, V) __sync_add_and_fetch((P), (V))
 
 /* Compile read-write barrier */
-#define barrier() __asm__ volatile("": : :"memory")
+#define barrier() __sync_synchronize ()
 
-/* Pause instruction to prevent excess processor bus usage */
+/* Pause instruction to prevent excess processor bus usage (when possible) */
+#if defined(__i386) || defined(__x86_64__)
 #define cpu_relax() __asm__ volatile("pause\n": : :"memory")
+#elif defined(__powerpc__) || defined(__ppc__) || defined(__PPC__) \
+	|| defined(__powerpc64__) || defined(__ppc64__) || defined(__PPC64__)
+#define cpu_relax() __asm__ volatile("or 27,27,27\n": : :"memory")
+#elif defined(__ARM_ARCH_6T2__) || defined(__ARM_ARCH_7__) || defined(__ARM_ARCH_7A__) \
+	|| defined(__ARM_ARCH_7R__) || defined(__ARM_ARCH_7M__) \
+	|| defined(__ARM_ARCH_7S__) || defined(__aarch64__)
+#define cpu_relax() __asm__ volatile("yield\n": : :"memory")
+#else
+#define cpu_relax()
+#endif
 
 /* Atomic exchange (of various sizes) */
 static inline uint64_t atomic_xchg64(void *ptr, uint64_t x)
 {
-	__asm__ __volatile__("xchgq %0,%1"
-			:"=r" (x)
-			:"m" (*(volatile uint64_t *)ptr), "0" (x)
-			:"memory");
-
-	return x;
+	// translates to an xchg instruction and returns oldval
+	return __sync_lock_test_and_set ((uint64_t *) ptr, x);
 }
 
-static inline unsigned atomic_xchg32(void *ptr, uint32_t x)
+static inline uint32_t atomic_xchg32(void *ptr, uint32_t x)
 {
-	__asm__ __volatile__("xchgl %0,%1"
-			:"=r" (x)
-			:"m" (*(volatile uint32_t *)ptr), "0" (x)
-			:"memory");
-
-	return x;
+	// translates to an xchg instruction and returns oldval
+	return __sync_lock_test_and_set ((uint32_t *) ptr, x);
 }
 
 static inline void atomic_add64d(double *src, double val)

--- a/src/atomic.h
+++ b/src/atomic.h
@@ -21,7 +21,7 @@
 	|| defined(__ARM_ARCH_7S__) || defined(__aarch64__)
 #define cpu_relax() __asm__ volatile("yield\n": : :"memory")
 #else
-#define cpu_relax()
+#define cpu_relax() break
 #endif
 
 /* Atomic exchange (of various sizes) */


### PR DESCRIPTION
Used compiled intrinsics where possible and added instructions for other architectures. I also changed the `cpu_relax()` macro to work across architectures and actually yield accesses to other cores when possible (x86(_64), Power{PC,1,2,3,4,5,6,7,8}, ARMv6T2+, ARM64).

Tested to compile cleanly on:

 - GCC
   - 4.9.0
   - 4.9.2
   - 5.1.0
 - Clang
   - 3.3
   - 3.4.1
   - 3.5.1
   - 3.6.rc2
 - Intel CC 13.0.1
 - GCC ARM64 4.8
 - GCC ARM 4.8.2
 - GCC PowerPC 4.8