### PR TITLE
Implement HTTP endpoint using libmicrohttpd

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,9 +29,9 @@ SOURCES = \
 	src/slab.c \
 	src/utils.c
 
-ifdef BRUBECK_HTTP
-	SOURCES += src/http/mongoose.c
-	CFLAGS += -DBRUBECK_HAVE_MONGOOSE
+ifndef BRUBECK_NO_HTTP
+	LIBS += -lmicrohttpd
+	CFLAGS += -DBRUBECK_HAVE_MICROHTTPD
 endif
 
 OBJECTS = $(patsubst %.c, %.o, $(SOURCES))

--- a/README.md
+++ b/README.md
@@ -54,6 +54,15 @@ Brubeck answers to the following signals:
 - `SIGUSR2`: dump a newline-separated list of all the metrics currently aggregated by the
     daemon and their types.
 
+### HTTP Endpoint
+
+If enabled on the config file, Brubeck can provide an HTTP API to poll its status. The following routes are available:
+
+- `GET /ping`: return a short JSON payload with the current status of the daemon (just to check it's up)
+- `GET /stats`: get a large JSON payload with full statistics, including active endpoints and throughputs
+- `GET /metric/{{metric_name}}`: get the current status of a metric, if it's being aggregated
+- `POST /expire/{{metric_name}}`: expire a metric that is no longer being reported to stop it from being aggregated to the backend
+
 ## Configuration
 
 The configuration for Brubeck is loaded through a JSON file, passed on the commandline.

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ Brubeck has the following dependencies:
 
 - OpenSSL (`libcrypto`) if you're building StatsD-Secure support
 
+- libmicrohttpd (`libmicrohttpd-dev`) to have an internal HTTP stats endpoint. Build with `BRUBECK_NO_HTTP` to disable this.
+
 Build brubeck by typing:
 
     ./script/bootstrap

--- a/config.default.json.example
+++ b/config.default.json.example
@@ -5,6 +5,7 @@
   "dumpfile" : "./brubeck.dump",
   "capacity" : 15,
   "expire" : 5,
+  "http" : ":8080",
 
   "backends" : [
     {


### PR DESCRIPTION
We had to remove the internal stats endpoint because it was using Moongoose (a GPLv2 licensed embedded HTTP server). This made me sad.

I've replaced the Moongoose code here with `libmicrohttpd`, which is LGPLv2 licensed and can be linked safely against Brubeck without affecting its license.

APIs and functionality remain unchanged. You can now `make BRUBECK_NO_HTTP=1` if you don't have libmicrohttpd available.

cc @jssjr @samlambert @bkeepers 