### PR TITLE
util: Allow hostnames in `url_to_inaddr2`

### DIFF
--- a/config.default.json.example
+++ b/config.default.json.example
@@ -10,7 +10,7 @@
   "backends" : [
     {
       "type" : "carbon",
-      "address" : "0.0.0.0",
+      "address" : "localhost",
       "port" : 2003,
       "frequency" : 10
     }


### PR DESCRIPTION
Fixes #19 by using `getaddrinfo` instead of attempting to manually translate an IP.