### PR TITLE
Adding carbon metric namespacing

### DIFF
--- a/src/backend.h
+++ b/src/backend.h
@@ -12,7 +12,7 @@ struct brubeck_backend {
 	int shard_n;
 
 	int (*connect)(void *);
-	void (*sample)(const char *, value_t, void *);
+	void (*sample)(const struct brubeck_metric*, const char *, value_t, void *);
 	void (*flush)(void *);
 
 	uint32_t tick_time;

--- a/src/backends/carbon.h
+++ b/src/backends/carbon.h
@@ -16,9 +16,19 @@ struct brubeck_carbon {
 			uint16_t pt;
 	} pickler;
 	size_t sent;
+
+	int namespacing;
+	int legacy_namespace;
+	const char *global_prefix;
+	const char *global_count_prefix;
+	const char *prefix_counter;
+	const char *prefix_timer;
+	const char *prefix_gauge;
 };
 
 struct brubeck_backend *brubeck_carbon_new(
 	struct brubeck_server *server, json_t *settings, int shard_n);
+
+#define IS_COUNTER(t) (t == BRUBECK_MT_COUNTER || t == BRUBECK_MT_METER)
 
 #endif

--- a/src/internal_sampler.c
+++ b/src/internal_sampler.c
@@ -13,43 +13,43 @@ brubeck_internal__sample(struct brubeck_metric *metric, brubeck_sample_cb sample
 
 	WITH_SUFFIX(".metrics") {
 		value = brubeck_atomic_swap(&stats->metrics, 0);
-		sample(key, value, opaque);
+		sample(metric, key, value, opaque);
 	}
 
 	WITH_SUFFIX(".errors") {
 		value = brubeck_atomic_swap(&stats->errors, 0);
-		sample(key, value, opaque);
+		sample(metric, key, value, opaque);
 	}
 
 	WITH_SUFFIX(".unique_keys") {
 		value = brubeck_atomic_fetch(&stats->unique_keys);
-		sample(key, value, opaque);
+		sample(metric, key, value, opaque);
 	}
 
 	WITH_SUFFIX(".memory") {
 		value = brubeck_atomic_fetch(&stats->memory);
-		sample(key, value, opaque);
+		sample(metric, key, value, opaque);
 	}
 
 	/* Secure statsd endpoint */
 	WITH_SUFFIX(".secure.failed") {
 		value = brubeck_atomic_swap(&stats->secure.failed, 0);
-		sample(key, value, opaque);
+		sample(metric, key, value, opaque);
 	}
 
 	WITH_SUFFIX(".secure.from_future") {
 		value = brubeck_atomic_swap(&stats->secure.from_future, 0);
-		sample(key, value, opaque);
+		sample(metric, key, value, opaque);
 	}
 
 	WITH_SUFFIX(".secure.delayed") {
 		value = brubeck_atomic_swap(&stats->secure.delayed, 0);
-		sample(key, value, opaque);
+		sample(metric, key, value, opaque);
 	}
 
 	WITH_SUFFIX(".secure.replayed") {
 		value = brubeck_atomic_swap(&stats->secure.replayed, 0);
-		sample(key, value, opaque);
+		sample(metric, key, value, opaque);
 	}
 
 	/*

--- a/src/metric.c
+++ b/src/metric.c
@@ -52,7 +52,7 @@ gauge__sample(struct brubeck_metric *metric, brubeck_sample_cb sample, void *opa
 	}
 	pthread_spin_unlock(&metric->lock);
 
-	sample(metric->key, value, opaque);
+	sample(metric, metric->key, value, opaque);
 }
 
 
@@ -83,7 +83,7 @@ meter__sample(struct brubeck_metric *metric, brubeck_sample_cb sample, void *opa
 	}
 	pthread_spin_unlock(&metric->lock);
 
-	sample(metric->key, value, opaque);
+	sample(metric, metric->key, value, opaque);
 }
 
 
@@ -122,7 +122,7 @@ counter__sample(struct brubeck_metric *metric, brubeck_sample_cb sample, void *o
 	}
 	pthread_spin_unlock(&metric->lock);
 
-	sample(metric->key, value, opaque);
+	sample(metric, metric->key, value, opaque);
 }
 
 
@@ -160,47 +160,47 @@ histogram__sample(struct brubeck_metric *metric, brubeck_sample_cb sample, void 
 	memcpy(key, metric->key, metric->key_len);
 
 	WITH_SUFFIX(".min") {
-		sample(key, hsample.min, opaque);
+		sample(metric, key, hsample.min, opaque);
 	}
 
 	WITH_SUFFIX(".max") {
-		sample(key, hsample.max, opaque);
+		sample(metric, key, hsample.max, opaque);
 	}
 
 	WITH_SUFFIX(".sum") {
-		sample(key, hsample.sum, opaque);
+		sample(metric, key, hsample.sum, opaque);
 	}
 
 	WITH_SUFFIX(".mean") {
-		sample(key, hsample.mean, opaque);
+		sample(metric, key, hsample.mean, opaque);
 	}
 
 	WITH_SUFFIX(".count") {
-		sample(key, hsample.count, opaque);
+		sample(metric, key, hsample.count, opaque);
 	}
 
 	WITH_SUFFIX(".median") {
-		sample(key, hsample.median, opaque);
+		sample(metric, key, hsample.median, opaque);
 	}
 
 	WITH_SUFFIX(".percentile.75") {
-		sample(key, hsample.percentile[PC_75], opaque);
+		sample(metric, key, hsample.percentile[PC_75], opaque);
 	}
 
 	WITH_SUFFIX(".percentile.95") {
-		sample(key, hsample.percentile[PC_95], opaque);
+		sample(metric, key, hsample.percentile[PC_95], opaque);
 	}
 
 	WITH_SUFFIX(".percentile.98") {
-		sample(key, hsample.percentile[PC_98], opaque);
+		sample(metric, key, hsample.percentile[PC_98], opaque);
 	}
 
 	WITH_SUFFIX(".percentile.99") {
-		sample(key, hsample.percentile[PC_99], opaque);
+		sample(metric, key, hsample.percentile[PC_99], opaque);
 	}
 
 	WITH_SUFFIX(".percentile.999") {
-		sample(key, hsample.percentile[PC_999], opaque);
+		sample(metric, key, hsample.percentile[PC_999], opaque);
 	}
 }
 

--- a/src/metric.h
+++ b/src/metric.h
@@ -47,6 +47,7 @@ struct brubeck_metric {
 };
 
 typedef void (*brubeck_sample_cb)(
+	const struct brubeck_metric *metric,
 	const char *key,
 	value_t value,
 	void *backend);


### PR DESCRIPTION
In statsd metrics that are outputted through to graphite are namespaced with rules described at https://github.com/etsy/statsd/blob/master/docs/namespacing.md

This change would also allow backends a way to inspect more information about metric data they are sending, such as the specific type of metric.

Feedback is always welcome.