### PR TITLE
support 'set' type metrics

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ SOURCES = \
 	src/samplers/statsd-secure.c \
 	src/samplers/statsd.c \
 	src/server.c \
+	src/set.c \
 	src/setproctitle.c \
 	src/slab.c \
 	src/utils.c

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ SOURCES = \
 	src/bloom.c \
 	src/city.c \
 	src/histogram.c \
+	src/hs.c \
 	src/ht.c \
 	src/http.c \
 	src/internal_sampler.c \

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Brubeck supports most of the metric types from statsd and many other implementat
 - `C` - Counters
 - `h` - Histograms
 - `ms` - Timers (in milliseconds)
+- `s` - Sets
 
 Client-sent sampling rates are ignored.
 

--- a/src/brubeck.h
+++ b/src/brubeck.h
@@ -39,6 +39,7 @@ struct brubeck_metric;
 #include "slab.h"
 #include "histogram.h"
 #include "hs.h"
+#include "set.h"
 #include "metric.h"
 #include "sampler.h"
 #include "backend.h"

--- a/src/brubeck.h
+++ b/src/brubeck.h
@@ -24,6 +24,10 @@
 #define MAX_ADDR 256
 
 typedef double value_t;
+typedef union {
+	value_t n;
+	char *s;
+} sample_value_t;
 typedef uint64_t hash_t;
 
 struct brubeck_server;

--- a/src/brubeck.h
+++ b/src/brubeck.h
@@ -38,6 +38,7 @@ struct brubeck_metric;
 #include "utils.h"
 #include "slab.h"
 #include "histogram.h"
+#include "hs.h"
 #include "metric.h"
 #include "sampler.h"
 #include "backend.h"

--- a/src/hs.c
+++ b/src/hs.c
@@ -1,0 +1,54 @@
+#include <stdlib.h>
+
+#include "brubeck.h"
+#include "../vendor/ck/src/ck_ht_hash.h"
+#include "ck_malloc.h"
+
+static unsigned long
+hs_hash(const void *object, unsigned long seed)
+{
+	const char *c = object;
+	return (unsigned long)MurmurHash64A(c, strlen(c), seed);
+}
+
+static bool
+hs_compare(const void *previous, const void *compare)
+{
+	return strcmp(previous, compare) == 0;
+}
+
+brubeck_hashset_t *
+brubeck_hashset_new(const uint64_t size)
+{
+	brubeck_hashset_t *hs = xmalloc(sizeof(brubeck_hashset_t));
+	if (!ck_hs_init(hs, CK_HS_MODE_DIRECT, hs_hash, hs_compare, &ALLOCATOR,
+			(uint64_t)size, 0xDD15EA5E)) {
+		free(hs);
+		return NULL;
+	}
+
+	return hs;
+}
+
+void
+brubeck_hashset_free(brubeck_hashset_t *hs)
+{
+	/* no-op */
+}
+
+bool
+brubeck_hashset_add(brubeck_hashset_t *hs, const char *key) {
+	if(NULL != ck_hs_get(hs, CK_HS_HASH(hs, hs_hash, key), key))
+		return true;
+
+	return ck_hs_put(hs, CK_HS_HASH(hs, hs_hash, key), xstrdup(key));
+}
+
+bool
+brubeck_hashset_clear(brubeck_hashset_t *hs) {
+	ck_hs_iterator_t iterator = CK_HS_ITERATOR_INITIALIZER;
+	void *key;
+	while(ck_hs_next(hs, &iterator, &key))
+		free(key);
+	return ck_hs_reset(hs);
+}

--- a/src/hs.h
+++ b/src/hs.h
@@ -1,0 +1,14 @@
+#ifndef _HS_H_
+#define _HS_H_
+
+#include <stdbool.h>
+#include "ck_hs.h"
+
+typedef struct ck_hs brubeck_hashset_t;
+
+brubeck_hashset_t * brubeck_hashset_new(const uint64_t size);
+void brubeck_hashset_free(brubeck_hashset_t *hs);
+bool brubeck_hashset_add(brubeck_hashset_t *hs, const char *key);
+bool brubeck_hashset_clear(brubeck_hashset_t *hs);
+
+#endif

--- a/src/ht.c
+++ b/src/ht.c
@@ -21,7 +21,7 @@ ht_free(void *p, size_t b, bool r)
 	free(p);
 }
 
-static struct ck_malloc ALLOCATOR = {
+struct ck_malloc ALLOCATOR = {
 	.malloc = ht_malloc,
 	.free = ht_free
 };

--- a/src/ht.h
+++ b/src/ht.h
@@ -3,6 +3,7 @@
 
 #include <stdbool.h>
 
+extern struct ck_malloc ALLOCATOR;
 struct brubeck_metric;
 typedef struct brubeck_hashtable_t brubeck_hashtable_t;
 

--- a/src/http.c
+++ b/src/http.c
@@ -27,7 +27,7 @@ static struct MHD_Response *
 send_metric(struct brubeck_server *server, const char *url)
 {
 	static const char *metric_types[] = {
-		"gauge", "meter", "counter", "histogram", "timer", "internal"
+		"gauge", "meter", "counter", "histogram", "timer", "set", "internal"
 	};
 	static const char *expire_status[] = {
 		"disabled", "inactive", "active"

--- a/src/metric.h
+++ b/src/metric.h
@@ -52,7 +52,7 @@ typedef void (*brubeck_sample_cb)(
 	void *backend);
 
 void brubeck_metric_sample(struct brubeck_metric *metric, brubeck_sample_cb cb, void *backend);
-void brubeck_metric_record(struct brubeck_metric *metric, value_t value);
+void brubeck_metric_record(struct brubeck_metric *metric, sample_value_t value);
 
 struct brubeck_metric *brubeck_metric_new(struct brubeck_server *server, const char *, size_t, uint8_t);
 struct brubeck_metric *brubeck_metric_find(struct brubeck_server *server, const char *, size_t, uint8_t);

--- a/src/metric.h
+++ b/src/metric.h
@@ -7,6 +7,7 @@ enum brubeck_metric_t {
 	BRUBECK_MT_COUNTER, /** C */
 	BRUBECK_MT_HISTO, /** h */
 	BRUBECK_MT_TIMER, /** ms */
+	BRUBECK_MT_SET, /** s */
 	BRUBECK_MT_INTERNAL_STATS
 };
 
@@ -39,6 +40,7 @@ struct brubeck_metric {
 		struct {
 			value_t value, previous;
 		} counter;
+		brubeck_hashset_t *set;
 		struct brubeck_histo histogram;
 		void *other;
 	} as;

--- a/src/samplers/statsd.h
+++ b/src/samplers/statsd.h
@@ -7,7 +7,7 @@ struct brubeck_statsd_msg {
     char *key;      /* The key of the message, NULL terminated */
     uint16_t key_len; /* length of the key */
     uint16_t type;	/* type of the messaged, as a brubeck_mt_t */
-    value_t value;	/* integer value of the message */
+    sample_value_t value;	/* value of the message */
     char *trail;    /* Any data following the 'key:value|type' construct, NULL terminated*/
 };
 

--- a/src/server.c
+++ b/src/server.c
@@ -76,7 +76,7 @@ expire_metric(struct brubeck_metric *mt, void *_)
 static void
 dump_metric(struct brubeck_metric *mt, void *out_file)
 {
-	static const char *METRIC_NAMES[] = {"g", "c", "C", "h", "ms", "internal"};
+	static const char *METRIC_NAMES[] = {"g", "c", "C", "h", "ms", "s", "internal"};
 	fprintf((FILE *)out_file, "%s|%s\n", mt->key, METRIC_NAMES[mt->type]);
 }
 

--- a/src/set.c
+++ b/src/set.c
@@ -1,0 +1,23 @@
+#include "brubeck.h"
+
+#define SET_INIT_SIZE 16
+
+void brubeck_set_add(struct brubeck_metric *metric, const char *key) {
+	if(NULL == metric->as.set)
+		metric->as.set = brubeck_hashset_new(SET_INIT_SIZE);
+
+	if(NULL != metric->as.set)
+		brubeck_hashset_add(metric->as.set, key);
+}
+
+size_t
+brubeck_set_size(brubeck_hashset_t *hs)
+{
+	return ck_hs_count(hs);
+}
+
+bool
+brubeck_set_clear(brubeck_hashset_t *hs)
+{
+	return brubeck_hashset_clear(hs);
+}

--- a/src/set.h
+++ b/src/set.h
@@ -1,0 +1,8 @@
+#ifndef __BRUBECK_SET_H__
+#define __BRUBECK_SET_H__
+
+void brubeck_set_add(struct brubeck_metric *metric, const char *key);
+size_t brubeck_set_size(brubeck_hashset_t *hs);
+bool brubeck_set_clear(brubeck_hashset_t *hs);
+
+#endif

--- a/src/utils.h
+++ b/src/utils.h
@@ -57,6 +57,13 @@ static inline void *xrealloc(void *ptr, size_t size)
 	return new_ptr;
 }
 
+// strdup
+static inline char *xstrdup(const char *s)
+{
+	void *ptr = xmalloc(strlen(s) + 1);
+	return strcpy(ptr, s);
+}
+
 #define brubeck_atomic_inc(P) __sync_add_and_fetch((P), 1)
 #define brubeck_atomic_dec(P) __sync_add_and_fetch((P), -1)
 #define brubeck_atomic_add(P, V) __sync_add_and_fetch((P), (V))

--- a/tests/statsd_msg.c
+++ b/tests/statsd_msg.c
@@ -10,7 +10,17 @@ static void try_parse(struct brubeck_statsd_msg *msg, const char *msg_text, doub
 	memcpy(buffer, msg_text, len);
 
 	sput_fail_unless(brubeck_statsd_msg_parse(msg, buffer, len) == 0, msg_text);
-	sput_fail_unless(expected == msg->value, "msg.value == expected");
+	sput_fail_unless(expected == msg->value.n, "msg.value.n == expected");
+}
+
+static void try_parse_set(struct brubeck_statsd_msg *msg, const char *msg_text, const char *expected)
+{
+	char buffer[64];
+	size_t len = strlen(msg_text);
+	memcpy(buffer, msg_text, len);
+
+	sput_fail_unless(brubeck_statsd_msg_parse(msg, buffer, len) == 0, msg_text);
+	sput_fail_unless(0 == strcmp(msg->value.s, expected), "msg.value.s == expected");
 }
 
 void test_statsd_msg__parse_strings(void)
@@ -26,4 +36,8 @@ void test_statsd_msg__parse_strings(void)
 	try_parse(&msg, "this.is.sparta:23.23|g", 23.23);
 	try_parse(&msg, "this.is.sparta:0.232030|g", 0.23203);
 	try_parse(&msg, "this.are.some.floats:1234567.89|g", 1234567.89);
+
+#define EXPECT "some.non-float.value"
+	try_parse_set(&msg, "this.is.a.set:" EXPECT "|s|@args", EXPECT);
+	try_parse_set(&msg, "this.is.a.set:" EXPECT "|s", EXPECT);
 }


### PR DESCRIPTION
etsy statsd supports metrics of type `set`. This PR adds request for the set type to brubeck.

https://github.com/etsy/statsd/blob/master/docs/metric_types.md#sets