### PR TITLE
adding support for uppercase scientific notation

### DIFF
--- a/src/samplers/statsd.c
+++ b/src/samplers/statsd.c
@@ -130,7 +130,7 @@ parse_float(char *buffer, value_t *result, uint8_t *mods)
 	if (negative)
 		value = -value;
 
-	if (unlikely(*buffer == 'e'))
+	if (unlikely(*buffer == 'e' || *buffer == 'E'))
 		value = strtod(start, &buffer);
 
 	*result = value;


### PR DESCRIPTION
The title is self explanatory. Small change to fix our issues, thought it might help others in the future. This has not yet been thoroughly tested on our kit but it seems to work (no dropped packets).

p.s. this is performing so much better than statsd for us, thanks for releasing this.