### PR TITLE
Fix a bug whereby all values > 2^31 were clamped to 2^31 in the carbo…

### DIFF
--- a/src/utils.c
+++ b/src/utils.c
@@ -112,7 +112,7 @@ void url_to_inaddr2(struct sockaddr_in *addr, const char *url, int port)
 
 #define FLOAT_PRECISION 4
 
-int brubeck_itoa(char *ptr, uint32_t number)
+int brubeck_itoa(char *ptr, uint64_t number)
 {
 	char *origin = ptr;
 	int size;

--- a/src/utils.h
+++ b/src/utils.h
@@ -15,7 +15,7 @@ void sock_enlarge_in(int fd);
 
 char *find_substr(const char *s, const char *find, size_t slen);
 
-int brubeck_itoa(char *ptr, uint32_t number);
+int brubeck_itoa(char *ptr, uint64_t number);
 int brubeck_ftoa(char *outbuf, float f);
 
 static inline int starts_with(const char *str, const char *prefix)

--- a/tests/ftoa.c
+++ b/tests/ftoa.c
@@ -10,7 +10,7 @@ static void check_eq(float f, const char *str)
 
 void test_ftoa(void)
 {
-	check_eq(0.0, "0");
+	check_eq( 0.0, "0");
 	check_eq(15.0, "15");
 	check_eq(15.5, "15.5");
 	check_eq(15.505, "15.505");
@@ -18,4 +18,6 @@ void test_ftoa(void)
 	check_eq(1234.567, "1234.567");
 	check_eq(99999.999, "100000");
 	check_eq(0.999, "0.999");
+        check_eq(161061273600.0, "161061273600");
+        check_eq(2147483649, "2147483649");
 }


### PR DESCRIPTION
This is a very serious bug where if your stats are > maximum of signed int, the carbon output is clamped to 2^31. 