### PR TITLE
Handle change metric type on-the-fly (without brubeck restart)

### DIFF
--- a/src/metric.c
+++ b/src/metric.c
@@ -299,13 +299,16 @@ struct brubeck_metric *
 brubeck_metric_new(struct brubeck_server *server, const char *key, size_t key_len, uint8_t type)
 {
 	struct brubeck_metric *metric;
+	char brubeck_metric_key[key_len + 2];
+
+	sprintf(brubeck_metric_key, "%s %u", key, type);
 
 	metric = new_metric(server, key, key_len, type);
 	if (!metric)
 		return NULL;
 
-	if (!brubeck_hashtable_insert(server->metrics, metric->key, metric->key_len, metric))
-		return brubeck_hashtable_find(server->metrics, key, key_len);
+	if (!brubeck_hashtable_insert(server->metrics, brubeck_metric_key, key_len + 2, metric))
+		return brubeck_hashtable_find(server->metrics, brubeck_metric_key, key_len + 2);
 
 	brubeck_backend_register_metric(brubeck_metric_shard(server, metric), metric);
 
@@ -318,9 +321,12 @@ struct brubeck_metric *
 brubeck_metric_find(struct brubeck_server *server, const char *key, size_t key_len, uint8_t type)
 {
 	struct brubeck_metric *metric;
+	char brubeck_metric_key[key_len + 2];
+
+	sprintf(brubeck_metric_key, "%s %u", key, type);
 
 	assert(key[key_len] == '\0');
-	metric = brubeck_hashtable_find(server->metrics, key, (uint16_t)key_len);
+	metric = brubeck_hashtable_find(server->metrics, brubeck_metric_key, ((uint16_t)key_len) + 2);
 
 	if (unlikely(metric == NULL)) {
 		if (server->at_capacity)


### PR DESCRIPTION
Hi
Looks like that current implementation does not handle change
metric type on-the-fly (without restarting brubeck).
This patchset fix this expanding hashtable key by adding space and metric type:
**metric_name + ' ' + metric_type**
If You may fix this more clearly - it will be perfect, thanks in advance!

More detailed description:

1. Start brubeck with config:
```
{
  "sharding" : false,
  "server_name" : "brubeck_debug",
  "dumpfile" : "./brubeck.dump",
  "capacity" : 15,
  "expire" : 10,
  "http" : ":8888",

  "backends" : [
    {
      "type" : "carbon",
      "address" : "localhost",
      "port" : 2003,
      "frequency" : 10
    }
  ],

  "samplers" : [
    {
      "type" : "statsd",
      "address" : "0.0.0.0",
      "port" : 8126,
      "workers" : 4,
      "multisock" : true,
      "multimsg" : 8
    },
    {
      "type" : "statsd-secure",
      "address" : "0.0.0.0",
      "port" : 9126,
	  "max_drift" : 3,
	  "hmac_key" : "750c783e6ab0b503eaa86e310a5db738",
	  "replay_len" : 8000
    }
  ]
}
```

2. Send metrics **as counter type** and see network traffic between brubeck
and graphite storage (I use go-carbon):
```
while true; do (echo "send counter" ; echo "deploy.test.myservice:1|c" \
| socat -t 0 - udp-sendto:127.0.0.1:8126; sleep 1); done
...
ngrep -d any -q "test" port 2003
...
T 127.0.0.1:53600 -> 127.0.0.1:2003 [AP]
  deploy.test.myservice 10 1482680939. # valid, we collect sum = 1 * frequency = 10
```

3. Change metric type only (**counter -> gauge**), **name stays same**,
and see network traffic between brubeck and graphite storage (I use go-carbon),
**brubeck continues handle this metric as counter, not as gauge:**
```
while true; do (echo "send gauge" ; echo "deploy.test.myservice:1|g" \
| socat -t 0 - udp-sendto:127.0.0.1:8126; sleep 1); done
...
ngrep -d any -q "test" port 2003
...
T 127.0.0.1:53600 -> 127.0.0.1:2003 [AP]
  deploy.test.myservice 10 1482680979. # invalid, must be '1', not '10'

```