### PR TITLE
issue_42_56: use actual number of received messages, not the expected…

### DIFF
--- a/src/samplers/statsd.c
+++ b/src/samplers/statsd.c
@@ -51,9 +51,9 @@ static void statsd_run_recvmmsg(struct brubeck_statsd *statsd, int sock)
 		}
 
 		/* store stats */
-		brubeck_atomic_add(&statsd->sampler.inflow, SIM_PACKETS);
+		brubeck_atomic_add(&statsd->sampler.inflow, res);
 
-		for (i = 0; i < SIM_PACKETS; ++i) {
+		for (i = 0; i < res; ++i) {
 			char *buf = msgs[i].msg_hdr.msg_iov->iov_base;
 			char *end = buf + msgs[i].msg_len;
 			brubeck_statsd_packet_parse(server, buf, end);


### PR DESCRIPTION
see problem manifestation description in: https://github.com/github/brubeck/issues/42, https://github.com/github/brubeck/issues/56

nature of the fix - ensure that code does not iterate thru elements that either have not been initialized or have residual values from previous `recvmmsg` call