### PR TITLE
README: mark the project as unmaintained

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,11 @@
-# Brubeck
+# Brubeck (unmaintained)
 
 Brubeck is a [statsd](https://github.com/etsy/statsd)-compatible stats
-aggregator written in C.
+aggregator written in C. Brubeck is currently unmaintained.
+
+## List of known maintained forks
+
+- https://github.com/lukepalmer/brubeck-new
 
 ## What is statsd?
 


### PR DESCRIPTION
Since Brubeck is not being actively maintained by anybody at GitHub, we're going to archive the repository and point people at @lukepalmer's fork, which is more up to date.